### PR TITLE
FSI-553 Error handling improvement

### DIFF
--- a/webhook_test.go
+++ b/webhook_test.go
@@ -32,6 +32,8 @@ func TestServeHTTP(t *testing.T) {
 		}
 	}
 
+	missingObjectRequestBody := bytes.Replace(makeTestData(t, "default"), []byte("\"object\""), []byte("\"foo\""), -1)
+
 	patchTypeForValidBody := v1beta1.PatchTypeJSONPatch
 	cases := []struct {
 		name                      string
@@ -93,10 +95,10 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			name:                      "mutation fails - object not present in request body",
-			requestBody:               bytes.Replace(makeTestData(t, "default"), []byte("\"object\""), []byte("\"foo\""), -1),
+			requestBody:               missingObjectRequestBody,
 			contentType:               "application/json",
-			expectedStatusCode:        http.StatusInternalServerError,
-			expectedBodyWhenHTTPError: "error during mutation: \"object not present in request body\"\n",
+			expectedStatusCode:        http.StatusBadRequest,
+			expectedBodyWhenHTTPError: fmt.Sprintf("object not present in request body: %q\n", missingObjectRequestBody),
 		},
 	}
 


### PR DESCRIPTION
This PR ensures we are commited to act as a non-intrusive mutating webhook.

From our docs:

> We are commited to keep the webhook as a non-intrusive mechanism for injecting the required env vars into the containers. In order to achieve this we took the following design decisions:
> 
> * The failurePolicy is set to Ignore. Any response from our webhook with a non success HTTP Status Code will be then skipped, so the Kubernetes API will continue the execution of the request lifecycle.
> * Any 200 OK response coming from the webhook contains allowed: true within the response included in the body. This tells the Kubernetes API that the creation of such workload is allowed, letting then to continue the execution of the request lifecycle.