### PR TITLE
FSI-596 The k8s-webhook-cert-manager is now agnostic from New Relic

### DIFF
--- a/deploy/job.yaml
+++ b/deploy/job.yaml
@@ -64,5 +64,14 @@ spec:
           # This is a minimal kubectl image based on Alpine Linux that sings certificates using the k8s extension api server
           image: quay.io/newrelic/k8s-metadata-injector-certs
           command: ["./generate_certificate.sh"]
+          args:
+            - "--service"
+            - "newrelic-metadata-injection-svc"
+            - "--webhook"
+            - "newrelic-metadata-injection-cfg"
+            - "--secret"
+            - "newrelic-metadata-injection-secret"
+            - "--namespace"
+            - "default"
       restartPolicy: Never
   backoffLimit: 1


### PR DESCRIPTION
This is the main requirement before moving the cert management script to a brand new repository.