### PR TITLE
Use minikube context in e2e tests

### DIFF
--- a/e2e-tests/tests.sh
+++ b/e2e-tests/tests.sh
@@ -97,6 +97,7 @@ export KUBECONFIG=$HOME/.kube/config
 [ -n "$E2E_START_MINIKUBE" ] && start_minikube
 
 minikube update-context
+kubectl config use-context minikube
 
 is_kube_running="false"
 


### PR DESCRIPTION
Force e2e tests to run in minikube context.