### PR TITLE
Human readable logger

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,7 +39,12 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	logger := setupLogger()
+	zapLogger, err := zap.NewDevelopment() // We want a human readable log that includes as much as detail as possible.
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+	logger := zapLogger.Sugar()
+
 	defer func() { _ = logger.Sync() }()
 
 	pair, err := tls.LoadX509KeyPair(s.TLSCertFile, s.TLSKeyFile)
@@ -141,14 +146,4 @@ func withLoggingMiddleware(logger *zap.SugaredLogger) func(next http.Handler) ht
 
 		return http.HandlerFunc(fn)
 	}
-}
-
-func setupLogger() *zap.SugaredLogger {
-	config := zap.NewProductionConfig()
-	config.OutputPaths = []string{"stdout"}
-	zapLogger, err := config.Build()
-	if err != nil {
-		log.Fatalf("can't initialize zap logger: %v", err)
-	}
-	return zapLogger.Sugar()
 }


### PR DESCRIPTION
The logs of the webhook should be human readable because only humans will process it.

As our application runs on K8s Clusters, we want to allow the user to read logs in order to debug, if needed, the webhook. 

Before:
```
{"level":"error","ts":1549291244.970731,"caller":"k8s-metadata-injection/main.go:47","msg":"failed to load key pair","err":"open /etc/tls-key-cert-pair/tls.crt: no such file or d
irectory","stacktrace":"main.main\n\t/Users/smoya/go/src/github.com/newrelic/k8s-metadata-injection/main.go:47\nruntime.main\n\t/usr/local/Cellar/go/1.11.4/libexec/src/runtime/pr
oc.go:201"}
```

After:
```
2019-02-04T15:43:18.958+0100    ERROR   k8s-metadata-injection/main.go:47       failed to load key pair {"err": "open /etc/tls-key-cert-pair/tls.crt: no such file or directory"}
main.main
        /Users/smoya/go/src/github.com/newrelic/k8s-metadata-injection/main.go:47
runtime.main
        /usr/local/Cellar/go/1.11.4/libexec/src/runtime/proc.go:201
```