### PR TITLE
Human readable timestamps in logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
@@ -145,7 +147,8 @@ func withLoggingMiddleware(logger *zap.SugaredLogger) func(next http.Handler) ht
 
 func setupLogger() *zap.SugaredLogger {
 	config := zap.NewProductionConfig()
-	config.OutputPaths = []string{"stdout"}
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder // We want human readable timestamps.
+
 	zapLogger, err := config.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)


### PR DESCRIPTION
Before:
```
{"level":"error","ts":1549291244.970731,"caller":"k8s-metadata-injection/main.go:47","msg":"failed to load key pair","err":"open /etc/tls-key-cert-pair/tls.crt: no such file or d
irectory","stacktrace":"main.main\n\t/Users/smoya/go/src/github.com/newrelic/k8s-metadata-injection/main.go:47\nruntime.main\n\t/usr/local/Cellar/go/1.11.4/libexec/src/runtime/pr
oc.go:201"}
```

After:
```
{"level":"error","ts":"2019-02-04T16:39:50.680+0100","caller":"k8s-metadata-injection/main.go:49","msg":"failed to load key pair","err":"open /etc/tls-key-cert-pair/tls.crt: no s
uch file or directory","stacktrace":"main.main\n\t/Users/smoya/go/src/github.com/newrelic/k8s-metadata-injection/main.go:49\nruntime.main\n\t/usr/local/Cellar/go/1.11.4/libexec/s
rc/runtime/proc.go:201"}
```