### PR TITLE
Avoid E2e potential race

### DIFF
--- a/e2e-tests/k8s-e2e-bootstraping.sh
+++ b/e2e-tests/k8s-e2e-bootstraping.sh
@@ -41,23 +41,24 @@ get_pod_name_by_label() {
 
 wait_for_pod() {
     set +e
-    is_pod_running=false
+    desired_status=${2:-'Running'}
+    is_pod_in_desired_status=false
     i=1
     while [ "$i" -ne 30 ]
     do
         pod_status="$(kubectl get pod "$1" -o jsonpath='{.status.phase}')"
-        if [ "$pod_status" = "Running" ] || [ "$pod_status" = "Succeeded" ]; then
-            is_pod_running=true
-            printf "pod %s is running\n" "$1"
+        if [ "$pod_status" = "$desired_status" ]; then
+            is_pod_in_desired_status=true
+            printf "pod %s is %s\n" "$1" "$desired_status"
             break
         fi
 
-        printf "Waiting for pod %s to be running\n" "$1"
+        printf "Waiting for pod %s to be %s\n" "$1" "$desired_status"
         sleep 3
         i=$((i + 1))
     done
-    if [ $is_pod_running = "false" ]; then
-        printf "pod %s does not start within 1 minute 30 seconds\n" "$1"
+    if [ $is_pod_in_desired_status = "false" ]; then
+        printf "pod %s does not transition to %s within 1 minute 30 seconds\n" "$1" "$desired_status"
         kubectl get pods
         kubectl describe pod "$1"
         exit 1


### PR DESCRIPTION
* The bootstrapping code now is updated with the recent changes made in the cert-manager repository.
* The tests have been updated. Now are waiting for the setup job to become `Succeeded` as it will mean the webhook has been patched successfully.