### PR TITLE
Run the webhook server on port 8443 to avoid need for root user

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,7 +29,7 @@ const (
 
 // specification contains the specs for this app.
 type specification struct {
-	Port        int           `default:"443"`                                                      // Webhook server port.
+	Port        int           `default:"8443"`                                                     // Webhook server port.
 	TLSCertFile string        `default:"/etc/tls-key-cert-pair/tls.crt" envconfig:"tls_cert_file"` // File containing the x509 Certificate for HTTPS.
 	TLSKeyFile  string        `default:"/etc/tls-key-cert-pair/tls.key" envconfig:"tls_key_file"`  // File containing the x509 private key for TLSCERTFILE.
 	ClusterName string        `default:"cluster" split_words:"true"`                               // The name of the Kubernetes cluster.

--- a/deploy/newrelic-metadata-injection.yaml
+++ b/deploy/newrelic-metadata-injection.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 443
+    targetPort: 8443
   selector:
     app: newrelic-metadata-injection
 ---


### PR DESCRIPTION
This is required for the metadata injection to work with OpenShift.