### PR TITLE
Change the default server timeout to 1s

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	appName        = "new-relic-k8s-metadata-injection"
+	appName = "new-relic-k8s-metadata-injection"
 )
 
 // specification contains the specs for this app.


### PR DESCRIPTION
This value doesn't care anymore about the timeout sent via URL parameter by the Kubernetes API server.

This is done to minimize the impact when, for whatever reason, the API server cannot properly reach the webhook server.

It's also possible to change this timeout via environment variables.