### PR TITLE
Add kubernetes.io/legacy-unknown signer with approve permission to rb…

### DIFF
--- a/deploy/job.yaml
+++ b/deploy/job.yaml
@@ -29,6 +29,12 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources:
+      - "signers"
+    resourceNames:
+      - "kubernetes.io/legacy-unknown"
+    verbs: ["approve"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
…ac for 1.18 compatibility

I tried this in 1.10, 1.16 and 1.18