### PR TITLE
ci: Upgrade actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   e2e-kubernetes:
     name: Kuebrnetes E2E tests
     needs: [ test ]
-    runs-on: ubuntu-18.04 # required by manusa/actions-setup-minikube@v2.0.1
+    runs-on: ubuntu-latest
     env:
       E2E_MINIKUBE_DRIVER: docker
     strategy:
@@ -35,7 +35,7 @@ jobs:
         k8s_version: [ "v1.15.12", "v1.16.15", "v1.17.14", "v1.18.12" ]
     steps:
       - uses: actions/checkout@v2
-      - uses: manusa/actions-setup-minikube@v2.0.1
+      - uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: v1.15.1
           kubernetes version: ${{ matrix.k8s_version }}


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).