### PR TITLE
bump helm chart on release

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,18 @@
+name: Update Helm Chart POMI version
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  create_helm_chart_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create PR using Version Bump
+        run: |
+          appVersion=${{ github.event.release.tag_name }}
+          chartName=nri-metadata-injection
+          curl -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Authorization: token ${{ secrets.VERSION_BUMP_TOKEN }}" \
+          --request POST \
+          --data '{"event_type": "bump-chart-version", "client_payload": { "chart_name": "${chartName}", "chart_version": "", "app_version": "${appVersion:1}"}}' \
+          https://api.github.com/repos/newrelic/helm-charts/dispatches


### PR DESCRIPTION
Job analogous to [nri-prometheus](https://github.com/newrelic/nri-prometheus/blob/main/.github/workflows/helm.yml)', which creates a PR bumping the `appVersion` of the helm chart associated to this repo in [helm-charts](https://github.com/newrelic/helm-charts).