### PR TITLE
Fix immutable selector

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 3.0.1
+version: 3.0.2
 appVersion: 1.7.0
 
 keywords:

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -9,7 +9,9 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "newrelic.common.labels.selectorLabels" . | nindent 6 }}
+      {{- /* We cannot use the common library here because of a legacy issue */}}
+      {{- /* `selector` is mnmutable and the previous chart did not have all the idiomatic labels */}}
+      app.kubernetes.io/name: {{ include "newrelic.common.naming.name" . }}
   template:
     metadata:
 {{- if .Values.podAnnotations }}

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       {{- /* We cannot use the common library here because of a legacy issue */}}
-      {{- /* `selector` is mnmutable and the previous chart did not have all the idiomatic labels */}}
+      {{- /* `selector` is immutable  and the previous chart did not have all the idiomatic labels */}}
       app.kubernetes.io/name: {{ include "newrelic.common.naming.name" . }}
   template:
     metadata:


### PR DESCRIPTION
`selector` is immutable and the previous chart did not have all the idiomatic labels so `nri-bundle` is failing to upgrade charts.