### PR TITLE
greatly reduce admission hook timeout

### DIFF
--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -56,7 +56,7 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 | priorityClassName | string | `""` | Sets pod's priorityClassName. Can be configured also with `global.priorityClassName` |
 | replicas | int | `1` |  |
 | resources | object | 100m/30M -/80M | Image for creating the needed certificates of this webhook to work |
-| timeoutSeconds | int | `28` | Webhook timeout Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts |
+| timeoutSeconds | int | `3` | Webhook timeout Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts |
 | tolerations | list | `[]` | Sets pod's tolerations to node taints. Can be configured also with `global.tolerations` |
 
 ## Maintainers

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -91,4 +91,4 @@ customTLSCertificate: false
 
 # -- Webhook timeout
 # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
-timeoutSeconds: 28
+timeoutSeconds: 3


### PR DESCRIPTION
The Admission webhooks introduced by New Relic are a major cause of
significant performance problems in GKE private clusters, as identified
in newrelic/k8s-metadata-injection#69.

While the root cause is the lack of access to port 8443, the problem is
worsened because the default timeout for such webhooks is 30 seconds.

This commit reduces the default to 3 seconds, which is a lot better, but
potentially could be lowered to even less, the communication happens
mostly between K8s control plane and the in-cluster service.

Note this has the pontential to further mask the problem in some
customers, reducing the performance problem to the point where people
might fail to notice it. The higher timeout is more prone to raising
people's attention. In my personal experience, however, my current
employer had this going for 6+ months before someone pinpointed the
scaling problems to New Relic.

In general, admission webooks must be fast. Very fast, so I don't think it makes sense to keep such high defaults anyway.