### PR TITLE
[chart] Template `imagePullSecrets` also they come from `global`

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 3.0.3
+version: 3.0.4
 appVersion: 1.7.0
 
 keywords:

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -1,6 +1,6 @@
 # nri-metadata-injection
 
-![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 3.0.4](https://img.shields.io/badge/Version-3.0.4-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic metadata injection webhook.
 

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -1,6 +1,6 @@
 # nri-metadata-injection
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic metadata injection webhook.
 
@@ -35,16 +35,17 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Sets pod/node affinities. Can be configured also with `global.affinity` |
 | certManager.enabled | bool | `false` | Use cert manager for webhook certs |
+| cluster | string | `""` | Name of the Kubernetes cluster monitored. Can be configured also with `global.cluster` |
 | containerSecurityContext | object | `{}` | Sets security context (at container level). Can be configured also with `global.containerSecurityContext` |
 | customTLSCertificate | bool | `false` | Use custom tls certificates for the webhook, or let the chart handle it automatically. Ref: https://docs.newrelic.com/docs/integrations/kubernetes-integration/link-your-applications/link-your-applications-kubernetes#configure-injection |
 | dnsConfig | object | `{}` | Sets pod's dnsConfig. Can be configured also with `global.dnsConfig` |
 | fullnameOverride | string | `""` | Override the full name of the release |
 | hostNetwork | bool | false | Sets pod's hostNetwork. Can be configured also with `global.hostNetwork` |
 | image | object | See `values.yaml` | Image for the New Relic Metadata Injector |
-| image.pullSecrets | string | `nil` | The secrets that are needed to pull images from a custom registry. |
+| image.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 | injectOnlyLabeledNamespaces | bool | `false` | Enable the metadata decoration only for pods living in namespaces labeled with 'newrelic-metadata-injection=enabled'. |
 | jobImage | object | See `values.yaml` | Image for creating the needed certificates of this webhook to work |
-| jobImage.pullSecrets | string | `nil` | The secrets that are needed to pull images from a custom registry. |
+| jobImage.pullSecrets | list | `[]` | The secrets that are needed to pull images from a custom registry. |
 | jobImage.volumeMounts | list | `[]` | Volume mounts to add to the job, you might want to mount tmp if Pod Security Policies Enforce a read-only root. |
 | jobImage.volumes | list | `[]` | Volumes to add to the job container |
 | labels | object | `{}` | Additional labels for chart objects. Can be configured also with `global.labels` |

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -18,9 +18,9 @@ spec:
         app: {{ include "nri-metadata-injection.name.admission-create" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- if .Values.jobImage.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.jobImage.pullSecrets ) "context" .) }}
       imagePullSecrets:
-        {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.jobImage.pullSecrets ) "context" .) | nindent 8 -}}
+        {{- . | nindent 8 -}}
       {{- end }}
       containers:
         - name: create

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -18,9 +18,9 @@ spec:
         app: {{ include "nri-metadata-injection.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- if .Values.jobImage.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.jobImage.pullSecrets ) "context" .) }}
       imagePullSecrets:
-{{ toYaml .Values.jobImage.pullSecrets | indent 8 }}
+        {{- . | nindent 8 -}}
       {{- end }}
       containers:
         - name: patch

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -37,9 +37,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
 
-      {{- if .Values.image.pullSecrets }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) }}
       imagePullSecrets:
-        {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) | nindent 8 -}}
+        {{- . | nindent 8 -}}
       {{- end }}
       containers:
       - name: {{ include "newrelic.common.naming.name" . }}

--- a/charts/nri-metadata-injection/templates/deployment.yaml
+++ b/charts/nri-metadata-injection/templates/deployment.yaml
@@ -25,6 +25,18 @@ spec:
       securityContext:
         {{- . | nindent 8 -}}
       {{- end }}
+      {{- with include "newrelic.common.priorityClassName" . }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with include "newrelic.common.dnsConfig" . }}
+      dnsConfig:
+        {{- . | nindent 8 }}
+      {{- end }}
+      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
+      {{- if include "newrelic.common.hostNetwork" . }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" ( list .Values.image.pullSecrets ) "context" .) | nindent 8 -}}
@@ -54,15 +66,12 @@ spec:
           periodSeconds: 1
         {{- if .Values.resources }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{ toYaml .Values.resources | nindent 10 }}
         {{- end }}
       volumes:
       - name: tls-key-cert-pair
         secret:
           secretName: {{ include "nri-metadata-injection.fullname.admission" . }}
-      {{- with include "newrelic.common.priorityClassName" . }}
-      priorityClassName: {{ . }}
-      {{- end }}
       {{- with include "newrelic.common.nodeSelector" . }}
       nodeSelector:
         {{- . | nindent 8 -}}
@@ -74,9 +83,4 @@ spec:
       {{- with include "newrelic.common.affinity" . }}
       affinity:
         {{- . | nindent 8 -}}
-      {{- end }}
-      hostNetwork: {{ include "newrelic.common.hostNetwork.value" . }}
-      {{- with include "newrelic.common.dnsConfig" . }}
-      dnsConfig:
-        {{- . | nindent 8 }}
       {{- end }}

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -14,7 +14,7 @@ image:
   tag: ""  # Defaults to chart's appVersion
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
-  pullSecrets:
+  pullSecrets: []
   # - name: regsecret
 
 # -- Image for creating the needed certificates of this webhook to work
@@ -25,7 +25,7 @@ jobImage:
   tag: v1.1.1
   pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
-  pullSecrets:
+  pullSecrets: []
   # - name: regsecret
 
   # -- Volume mounts to add to the job, you might want to mount tmp if Pod Security Policies


### PR DESCRIPTION
This chart was ignoring `global.images.pullSecrets` because it was testing only the local ones.

This should fix the issue.