### PR TITLE
[helm chart] Patch job should also honor the global service account flag

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 3.0.5
+version: 3.0.6
 appVersion: 1.7.0
 
 keywords:

--- a/charts/nri-metadata-injection/templates/_helpers.tpl
+++ b/charts/nri-metadata-injection/templates/_helpers.tpl
@@ -23,6 +23,14 @@ Naming helpers
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "admission") }}
 {{- end -}}
 
+{{- define "nri-metadata-injection.fullname.admission.serviceAccount" -}}
+{{- if include "newrelic.common.serviceAccount.create" . -}}
+  {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.fullname" .) "suffix" "admission") }}
+{{- else -}}
+  {{ include "newrelic.common.serviceAccount.name" . }}
+{{- end -}}
+{{- end -}}
+
 {{- define "nri-metadata-injection.name.admission-create" -}}
 {{ include "newrelic.common.naming.truncateToDNSWithSuffix" (dict "name" (include "newrelic.common.naming.name" .) "suffix" "admission-create") }}
 {{- end -}}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
@@ -15,6 +15,6 @@ roleRef:
   name: {{ include "nri-metadata-injection.fullname.admission" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "nri-metadata-injection.fullname.admission" . }}
+    name: {{ include "nri-metadata-injection.fullname.admission.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -42,7 +42,7 @@ spec:
       {{- .Values.jobImage.volumes | toYaml | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "nri-metadata-injection.fullname.admission" . }}
+      serviceAccountName: {{ include "nri-metadata-injection.fullname.admission.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -42,7 +42,7 @@ spec:
       {{- .Values.jobImage.volumes | toYaml | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "nri-metadata-injection.fullname.admission" . }}
+      serviceAccountName: {{ include "nri-metadata-injection.fullname.admission.serviceAccount" . }}
       securityContext:
         runAsGroup: 2000
         runAsNonRoot: true

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/rolebinding.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/rolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ include "nri-metadata-injection.fullname.admission" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "nri-metadata-injection.fullname.admission" . }}
+    name: {{ include "nri-metadata-injection.fullname.admission.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/serviceaccount.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/serviceaccount.yaml
@@ -1,8 +1,9 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- $createServiceAccount := include "newrelic.common.serviceAccount.create" . -}}
+{{- if (and $createServiceAccount (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "nri-metadata-injection.fullname.admission" . }}
+  name: {{ include "nri-metadata-injection.fullname.admission.serviceAccount" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade

--- a/charts/nri-metadata-injection/tests/job_serviceaccount_test.yaml
+++ b/charts/nri-metadata-injection/tests/job_serviceaccount_test.yaml
@@ -1,0 +1,35 @@
+suite: test job' serviceAccount
+templates:
+  - templates/admission-webhooks/job-patch/job-createSecret.yaml
+  - templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-release-nri-metadata-injection-admission
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default

--- a/charts/nri-metadata-injection/tests/rbac_test.yaml
+++ b/charts/nri-metadata-injection/tests/rbac_test.yaml
@@ -1,0 +1,35 @@
+suite: test RBAC creation
+templates:
+  - templates/admission-webhooks/job-patch/rolebinding.yaml
+  - templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: RBAC points to the service account that is created by default
+    set:
+      rbac.create: true
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: my-release-nri-metadata-injection-admission
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+      serviceAccount.name: sa-test
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: sa-test
+
+  - it: RBAC points to the service account the user supplies when serviceAccount is disabled
+    set:
+      rbac.create: true
+      serviceAccount.create: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: default


### PR DESCRIPTION
There is an issue open by GTS saying that not all the charts honor the flag `.global.serviceAccount.create` and `.global.serviceAccount.name`: newrelic/helm-charts#875

There is not also the issue that they are not honored by the deployments but also by the jobs that create and patch webhook certificates.
