### PR TITLE
fix(trivy): re-enable trivy for high vulnerabilities

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -69,7 +69,7 @@ jobs:
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          severity: 'CRITICAL'
+          severity: 'HIGH,CRITICAL'
       - name: Build and push docker image
         if: ${{ github.event.release.prerelease }}
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -24,7 +24,7 @@ jobs:
           scan-type: fs
           ignore-unfixed: true
           exit-code: 1
-          severity: 'CRITICAL'
+          severity: 'HIGH,CRITICAL'
 
       - name: Run Trivy vulnerability scanner sarif output
         uses: aquasecurity/trivy-action@0.2.2
@@ -32,7 +32,7 @@ jobs:
         with:
           scan-type: fs
           ignore-unfixed: true
-          severity: 'CRITICAL'
+          severity: 'HIGH,CRITICAL'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 # Set by docker automatically
 # If building with `docker build`, make sure to set GOOS/GOARCH explicitly when calling make:


### PR DESCRIPTION
In https://github.com/newrelic/nri-kubernetes/pull/517 I removed high vulnerabilities following the approach of https://github.com/newrelic/infrastructure-bundle/pull/207.

I think that was a mistake. In nri-bundle it makes sense since it is a collection of binaries and it would be too chatty. Here we can address vulnerabilities and if needed add them to the `.trivyignore` file with an explanation