### PR TITLE
There is no `lint` make target anymore

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -17,12 +17,16 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          only-new-issues: true
       - name: Build integration
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          make lint compile
+          make compile
       - name: Upload artifact for docker build step
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
We started to unify all the linting/testing processes through all the integrations.

Sustainability improved a lot, but in this repository, we forgot to refactor the release pipeline.

[`lint` make target was removed](https://github.com/newrelic/k8s-metadata-injection/commit/93e621342629ebb6f5b9801d45016ce352638cbf#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L40-L42) to use directly the `golangci-lint` action but we forgot to remove that from the release pipeline.

This PR should fix that issue.

![Screenshot 2022-09-13 at 14 49 29](https://user-images.githubusercontent.com/53659978/189905347-eb464636-5f66-42b4-97e7-3e31a4612b24.png)
