### PR TITLE
NEWRELIC-3912 Add nodeSelector support for jobs

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 3.0.8
+version: 3.0.9
 appVersion: 1.7.3
 
 keywords:

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -47,6 +47,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -47,6 +47,10 @@ spec:
         runAsGroup: 2000
         runAsNonRoot: true
         runAsUser: 2000
+      {{- with include "newrelic.common.nodeSelector" . }}
+      nodeSelector:
+        {{- . | nindent 8 -}}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}


### PR DESCRIPTION
Relates to https://github.com/newrelic/helm-charts/issues/932.

NodeSelectors are not being honoured in the jobs objects.