### PR TITLE
chart: disable PSPs by default

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -64,7 +64,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.7.1
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          minikube version: v1.20.0
+          minikube version: v1.27.1
           kubernetes version: ${{ matrix.kubernetes-version }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        k8s-version: [ "v1.16.15", "v1.17.17", "v1.18.16", "v1.19.8", "v1.20.4", "v1.21.3", "v1.22.0" ]
+        k8s-version: [ "v1.16.15", "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.16.15", "v1.22.0" ]
+        kubernetes-version: [ "v1.16.15", "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 3.0.10
+version: 4.0.0
 appVersion: 1.7.4
 
 keywords:

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
 version: 4.0.0
-appVersion: 1.7.4
+appVersion: 1.7.5
 
 keywords:
   - infrastructure

--- a/charts/nri-metadata-injection/README.md
+++ b/charts/nri-metadata-injection/README.md
@@ -53,6 +53,7 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 | podLabels | object | `{}` | Additional labels for chart pods. Can be configured also with `global.podLabels` |
 | podSecurityContext | object | `{}` | Sets security context (at pod level). Can be configured also with `global.podSecurityContext` |
 | priorityClassName | string | `""` | Sets pod's priorityClassName. Can be configured also with `global.priorityClassName` |
+| rbac.pspEnabled | bool | `false` | Whether the chart should create Pod Security Policy objects. |
 | replicas | int | `1` |  |
 | resources | object | 100m/30M -/80M | Image for creating the needed certificates of this webhook to work |
 | timeoutSeconds | int | `28` | Webhook timeout Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts |

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrole.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/clusterrole.yaml
@@ -17,9 +17,11 @@ rules:
     verbs:
       - get
       - update
+{{- if .Values.rbac.pspEnabled }}
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
     - {{ include "nri-metadata-injection.fullname.admission" . }}
+{{- end }}
 {{- end }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/psp.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/psp.yaml
@@ -1,4 +1,4 @@
-{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled)) }}
+{{- if (and (not .Values.customTLSCertificate) (not .Values.certManager.enabled) (.Values.rbac.pspEnabled)) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -39,6 +39,10 @@ jobImage:
   #  - name: tmp
   #    emptyDir: {}
 
+rbac:
+  # rbac.pspEnabled -- Whether the chart should create Pod Security Policy objects.
+  pspEnabled: false
+
 replicas: 1
 
 # -- Additional labels for chart objects. Can be configured also with `global.labels`


### PR DESCRIPTION
PSPs are removed in 1.25. Attempting to install this chart in 1.25 will result in an error, as the object the chart attempts to create does not exist in the cluster.

This PR adds a flag to control whether PSPs should be created and disables it by default.