### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.4
+
+- Fix: Update dependencies to address vulnerability issue (#234)
+
+## 1.7.3
+
+- Updated dependencies
+- Fix: Re-enable trivy for high vulnerabilities (#202)
+
+## 1.7.2
+
+- Fix: Update transitive dependencies to address trivy vulnerability issue (#164)
+
+## 1.7.1
+
+- Updated dependencies
+
 ## 1.7.0
 
 - Updated dependencies


### PR DESCRIPTION
Follow up of https://github.com/newrelic/k8s-metadata-injection/pull/234 to fix the [CVE-2022-32149](https://github.com/newrelic/k8s-metadata-injection/actions/runs/3295685547/jobs/5434484527).