### PR TITLE
Remove io/ioutil for io and os packages

### DIFF
--- a/src/server/webhook.go
+++ b/src/server/webhook.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -182,7 +182,7 @@ func (whsvr *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/src/server/webhook_test.go
+++ b/src/server/webhook_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
+
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,7 +20,7 @@ import (
 )
 
 func TestServeHTTP(t *testing.T) {
-	patchForValidBody, err := ioutil.ReadFile("testdata/expectedAdmissionReviewPatch.json")
+	patchForValidBody, err := os.ReadFile("testdata/expectedAdmissionReviewPatch.json")
 	if err != nil {
 		t.Fatalf("cannot read testdata file: %v", err)
 	}
@@ -121,7 +123,7 @@ func TestServeHTTP(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, c.expectedStatusCode, resp.StatusCode)
 
-			gotBody, err := ioutil.ReadAll(resp.Body)
+			gotBody, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("could not read body: %v", err)
 			}


### PR DESCRIPTION
Because of https://github.com/newrelic/k8s-metadata-injection/actions/runs/3378535842.