### PR TITLE
resolve the issue about MutatingWebhookConfiguration being not supported in v1beta1

### DIFF
--- a/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -32,4 +32,4 @@ webhooks:
   failurePolicy: Ignore
   timeoutSeconds: {{ .Values.timeoutSeconds }}
   sideEffects: None
-  admissionReviewVersions: ["v1"]
+  admissionReviewVersions: ["v1", "v1beta1"]

--- a/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -32,6 +32,4 @@ webhooks:
   failurePolicy: Ignore
   timeoutSeconds: {{ .Values.timeoutSeconds }}
   sideEffects: None
-  admissionReviewVersions:
-  - v1beta1
-  - v1
+  admissionReviewVersions: ["v1"]


### PR DESCRIPTION
According to the error message when a user encountered during newrelic bundle upgrade in this [issue](https://github.com/newrelic/helm-charts/issues/1027) , MutatingWebhookConfiguration is not supported by API version v1beta1. So remove the API version from this MutatingWebhookConfiguration definition.