### PR TITLE
#192 Added hook podAnnotations

### DIFF
--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 4.0.1
+version: 4.0.0
 appVersion: 1.7.5
 
 keywords:

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 4.0.0
+version: 4.0.1
 appVersion: 1.7.5
 
 keywords:

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -14,6 +14,8 @@ spec:
   template:
     metadata:
       name: {{ include "nri-metadata-injection.fullname.admission-create" . }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
         app: {{ include "nri-metadata-injection.name.admission-create" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -14,8 +14,10 @@ spec:
   template:
     metadata:
       name: {{ include "nri-metadata-injection.fullname.admission-create" . }}
+      {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "nri-metadata-injection.name.admission-create" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -14,6 +14,8 @@ spec:
   template:
     metadata:
       name: {{ include "nri-metadata-injection.fullname.admission-patch" . }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
         app: {{ include "nri-metadata-injection.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -14,8 +14,10 @@ spec:
   template:
     metadata:
       name: {{ include "nri-metadata-injection.fullname.admission-patch" . }}
+      {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "nri-metadata-injection.name.admission-patch" . }}
         {{- include "newrelic.common.labels" . | nindent 8 }}


### PR DESCRIPTION
As described at https://github.com/newrelic/k8s-metadata-injection/issues/192

When using istio side car injection the hooks get stuck since the istio container never stops. This PR will provide a way of setting the annotations in the hook to avoid such side car.