### PR TITLE
bump chart version and include a chart releaser action version change

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Add newrelic repository
         run: helm repo add newrelic https://helm-charts.newrelic.com
       - name: Release workload charts
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v4.1.1
+        uses: actions/github-script@v6.4.0
         with:
           script: |
-            const data = await github.repos.get(context.repo)
+            const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.7.6
+- Updated dependencies
+- Fix: Resolve the issue about MutatingWebhookConfiguration being not supported in v1beta1
+
 ## 1.7.5
 
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.7.6
+## 1.8.0
 - Updated dependencies
 - Fix: Resolve the issue about MutatingWebhookConfiguration being not supported in v1beta1
 

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,8 +9,8 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 4.0.1
-appVersion: 1.7.6
+version: 4.1.0
+appVersion: 1.8.0
 
 keywords:
   - infrastructure

--- a/charts/nri-metadata-injection/Chart.yaml
+++ b/charts/nri-metadata-injection/Chart.yaml
@@ -9,8 +9,8 @@ sources:
   - https://github.com/newrelic/k8s-metadata-injection
   - https://github.com/newrelic/k8s-metadata-injection/tree/master/charts/nri-metadata-injection
 
-version: 4.0.0
-appVersion: 1.7.5
+version: 4.0.1
+appVersion: 1.7.6
 
 keywords:
   - infrastructure


### PR DESCRIPTION
Main Changes

- [Resolve the issue about MutatingWebhookConfiguration being not supported in v1beta1](https://github.com/newrelic/k8s-metadata-injection/pull/260)
- merge/include multiple dependency bump PRs as follows
https://github.com/newrelic/k8s-metadata-injection/pull/249
https://github.com/newrelic/k8s-metadata-injection/pull/250
https://github.com/newrelic/k8s-metadata-injection/pull/253
https://github.com/newrelic/k8s-metadata-injection/pull/254
https://github.com/newrelic/k8s-metadata-injection/pull/256
https://github.com/newrelic/k8s-metadata-injection/pull/258
https://github.com/newrelic/k8s-metadata-injection/pull/259
https://github.com/newrelic/k8s-metadata-injection/pull/262 