### PR TITLE
Disable Helm chart version check

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,3 +5,6 @@ target-branch: main
 
 chart-repos:
   - newrelic=https://helm-charts.newrelic.com
+
+# Charts will be released manually.
+check-version-increment: false

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -38,4 +38,5 @@ jobs:
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1.5.0
         env:
+          CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR makes it easier to make changes to the helm chart without needing to also bump the version in the same PR.

