### PR TITLE
Update Kubernetes image registry

### DIFF
--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: create
-          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.jobImage "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.jobImage "context" .) }}
           imagePullPolicy: {{ .Values.jobImage.pullPolicy }}
           args:
             - create

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: patch
-          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "k8s.gcr.io" "imageRoot" .Values.jobImage "context" .) }}
+          image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.jobImage "context" .) }}
           imagePullPolicy: {{ .Values.jobImage.pullPolicy }}
           args:
             - patch

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -20,7 +20,7 @@ image:
 # -- Image for creating the needed certificates of this webhook to work
 # @default -- See `values.yaml`
 jobImage:
-  registry:  # Defaults to k8s.gcr.io
+  registry:  # Defaults to registry.k8s.io
   repository: ingress-nginx/kube-webhook-certgen
   tag: v1.3.0
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Fixes #274.

k8s.gcr.io image registry will be redirected to registry.k8s.io on Monday March 20th.
All images available in k8s.gcr.io are available at registry.k8s.io.

See https://kubernetes.io/blog/2023/03/10/image-registry-redirect/
