### PR TITLE
chore: Add labels to changelog workflow and renovatebot 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     // Disable the creation of this issue that renovate updates with the pending issue we follow with Zenhub:
     ":disableDependencyDashboard"
   ],
+  // Label PRs with `dependencies`.
+  "labels": ["dependencies"],
   "enabledManagers": [
     // Managers for helm and helm-values. Go dependencies are managed by Dependabot.
     "helm-values",

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
             echo "The CHANGELOG file was modified. Looks good!"
           else
             echo "The CHANGELOG file was not modified."
-            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\"."
+            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
             false
           fi
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   changelog-entry:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Before submitting an Issue, please search for similar ones in the
     + `enhancement`
     + `bugfix`
     + `dependency`
+
+  - You can skip the changelog requirement by using the "Skip Changelog" label if your pull request is only updating files related to the CI/CD process or minor doc changes.
     
 4. You may merge the Pull Request in once you have the sign-off of one other developers, or if you do not have permission to do that, you may request the other reviewer to merge it for you.
 


### PR DESCRIPTION
## Which problem is this PR solving?

We need to skip running the changelog workflow for dependency bump prs and for any prs that don't need a changelog like updating the codeowners files for example.

## Short description of the changes
- Updated changelog workflow to not run if a pr has a label of dependencies or Skip Changelog.
- Updated renovatebot to add a label of "dependencies". Note: dependabot already adds this label.

## Type of change

Please delete options that are not relevant.

- [x] New feature / enhancement (non-breaking change which adds functionality)

## New Tests?
Please describe the new tests that were added (if applicable).

Not applicable for this pr.

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated