### PR TITLE
fix: configuration of cert-manager cert durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### bugfix
+- Add configuration of certmanager durations @cdobbyn [#323](https://github.com/newrelic/k8s-metadata-injection/pull/323)
+
 
 ### enhancement
 - Add changelog workflow @svetlanabrennan [#316](https://github.com/newrelic/k8s-metadata-injection/pull/316)

--- a/charts/nri-metadata-injection/templates/cert-manager.yaml
+++ b/charts/nri-metadata-injection/templates/cert-manager.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: {{ include "newrelic.common.naming.fullname" . }}-root-cert
-  duration: 43800h # 5y
+  duration: {{ .Values.certManager.rootCertificateDuration}}
   issuerRef:
     name: {{ include "nri-metadata-injection.fullname.self-signed-issuer" . }}
   commonName: "ca.webhook.nri"
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: {{ include "nri-metadata-injection.fullname.admission" . }}
-  duration: 8760h # 1y
+  duration: {{ .Values.certManager.webhookCertificateDuration }}
   issuerRef:
     name: {{ include "nri-metadata-injection.fullname.root-issuer" . }}
   dnsNames:

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -76,6 +76,10 @@ containerSecurityContext: {}
 certManager:
   # certManager.enabled -- Use cert manager for webhook certs
   enabled: false
+  # -- Sets the root certificate duration. Defaults to 43800h (5 years).
+  rootCertificateDuration: 43800h
+  # -- Sets certificate duration. Defaults to 8760h (1 year).
+  webhookCertificateDuration: 8760h
 
 # -- Sets pod/node affinities. Can be configured also with `global.affinity`
 affinity: {}


### PR DESCRIPTION
## Which problem is this PR solving?
When we set `certManager.enabled: true` and deploy this via ArgoCD there is a diff error that occurs as the API returns:
- duration `43800h0m0s` for the root certificate
- duration `8760h0m0s` for the webhook certificate

## Short description of the changes
This PR allows us to configure these exact values and match what the API is returning thus removing the diff.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## New Tests?
n/a

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added - n/a
- [ ] Documentation has been updated - n/a