### PR TITLE
feat: do not set default resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### bugfix
+- Do not set resources by default @cdobbyn [#324](https://github.com/newrelic/k8s-metadata-injection/pull/324)
 
 ### enhancement
 - Add changelog workflow @svetlanabrennan [#316](https://github.com/newrelic/k8s-metadata-injection/pull/316)

--- a/charts/nri-metadata-injection/ci/test-values.yaml
+++ b/charts/nri-metadata-injection/ci/test-values.yaml
@@ -3,3 +3,11 @@ cluster: test-cluster
 image:
   repository: e2e/metadata-injection
   tag: test  # Defaults to AppVersion
+
+resources:
+  limits:
+    cpu: 150m
+    memory: 80Mi
+  requests:
+    cpu: 100m
+    memory: 30Mi

--- a/charts/nri-metadata-injection/tests/resources_test.yaml
+++ b/charts/nri-metadata-injection/tests/resources_test.yaml
@@ -1,0 +1,19 @@
+suite: check resources are properly set
+templates:
+  - templates/deployment.yaml
+release:
+  name: release
+  namespace: ns
+tests:
+  - it: resources are properly set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].resources.requests
+          content:
+            cpu: 100m
+            memory: 30Mi
+      - contains:
+          path: spec.template.spec.containers[0].resources.limits
+          content:
+            cpu: 150m
+            memory: 80Mi

--- a/charts/nri-metadata-injection/values.yaml
+++ b/charts/nri-metadata-injection/values.yaml
@@ -54,12 +54,12 @@ podLabels: {}
 
 # -- Image for creating the needed certificates of this webhook to work
 # @default -- 100m/30M -/80M
-resources:
-  limits:
-    memory: 80M
-  requests:
-    cpu: 100m
-    memory: 30M
+resources: {}
+#  limits:
+#    memory: 80M
+#  requests:
+#    cpu: 100m
+#    memory: 30M
 
 # -- Sets pod's priorityClassName. Can be configured also with `global.priorityClassName`
 priorityClassName: ""


### PR DESCRIPTION
## Which problem is this PR solving?

Helm standard is to not provide a resource default. This is because it does not play nice when templating the output and applying it with another tool like ArgoCD.

## Short description of the changes

This makes it so that there are no default settings for resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## New Tests?

Please describe the new tests that were added (if applicable).

- [x] This change requires changes in testing:
  - [x] chart tests

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Tests have been added
- [ ] Documentation has been updated - n/a