### PR TITLE
SECREV-2969: pin the action version using a full length SHA

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify failure via Slack
-        uses: archive/github-actions-slack@v2
+        uses: archive/github-actions-slack@d9dae40827adf93bddf939db6552d1e392259d7d
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}
           slack-channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### security
+- Meet internal security standards @jjaramillo [#334](https://github.com/newrelic/k8s-metadata-injection/pull/334)
+
 ## 1.11.0
 ## What's Changed
 - Add configuration of certmanager durations @cdobbyn [#323](https://github.com/newrelic/k8s-metadata-injection/pull/323)


### PR DESCRIPTION
## Which problem is this PR solving?

Security compliance: [SECREV-2969](https://newrelic.atlassian.net/browse/SECREV-2969)

## Short description of the changes

Pin third party action version using a full length SHA to meet security standards.

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?

Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated