### PR TITLE
Exclude renovate changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   changelog-entry:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.head_ref, 'renovate/')}}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Debug Labels
+        run: |
+          echo "${{ toJson(github.event.pull_request.labels[*].name) }}"
+          echo "Should Run: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}"
+
       - name: Check for CHANGELOG file changes
         run: |
           # Only the latest commit of the feature branch is available


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes the issue where the changelog workflow was running for renovatebot prs even though they had the "dependencies" label. This issue was happening because the label needs to be added before the pr is created which is not how renovate configuration works. 

So this pr just adds another check that if the head ref branch of the pr contains "renovate", then the workflow will not run. 

## Short description of the changes
- Add a check to see if the head ref branch starts with "renovate".

## Type of change

Please delete options that are not relevant.

- [x] New feature / enhancement (non-breaking change which adds functionality)

## New Tests?

Please describe the new tests that were added (if applicable).
NA

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated