### PR TITLE
chore: fix dockerfile in trigger prerelease workflow

### DIFF
--- a/.github/workflows/trigger_prerelease.yml
+++ b/.github/workflows/trigger_prerelease.yml
@@ -13,7 +13,7 @@ jobs:
   prerelease:
     uses: newrelic/coreint-automation/.github/workflows/trigger_prerelease.yaml@v1
     with:
-      rt-included-files: go.mod,go.sum,build/Dockerfile
+      rt-included-files: go.mod,go.sum,Dockerfile
       bot_email: '${{ vars.K8S_AGENTS_BOT_EMAIL }}'
       bot_name: '${{ vars.K8S_AGENTS_BOT_NAME }}'
     secrets:


### PR DESCRIPTION
## Which problem is this PR solving?

We don't have a `build/Dockerfile` so we need to replace it with use `Dockerfile` in the trigger prerelease workflow. 

## Short description of the changes
- Fixed  `rt-included-files` to use `Dockerfile` instead of `build/Dockerfile`

## Type of change

Please delete options that are not relevant.

- [ ] New feature / enhancement (non-breaking change which adds functionality)

## New Tests?
Please describe the new tests that were added (if applicable).

NA

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated