### PR TITLE
fix: Remove k8s version 1.16.15 from push_pr workflow

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        kubernetes-version: [ "v1.16.15", "v1.22.0", "v1.25.3" ]
+        kubernetes-version: [ "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -130,7 +130,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        k8s-version: [ "v1.16.15", "v1.22.0", "v1.25.3" ]
+        k8s-version: [ "v1.22.0", "v1.25.3" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
## Which problem is this PR solving?

Removing old version of k8s from push_pr workflow. It looks like k8s version 1.16.15 is having kubelet check issues. We're in the middle of deprecating old k8s versions so we will remove this version from this workflow for now. 

## Short description of the changes
- Removed 1.16.15 version from k8s-matrix

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?

Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated