### PR TITLE
temp: Add reusable changelog workflow

### DIFF
--- a/.github/workflows/changelog-reusable.yml
+++ b/.github/workflows/changelog-reusable.yml
@@ -1,0 +1,44 @@
+# This action requires that any PR should touch at
+# least one CHANGELOG file.
+
+name: Reusable changelog
+
+on:
+  workflow_call:
+
+jobs:
+  changelog-entry:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.head_ref, 'renovate/')}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Debug Labels
+        run: |
+          echo "${{ toJson(github.event.pull_request.labels[*].name) }}"
+          echo "Should Run: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.head_ref, 'renovate/')}}"
+
+      - name: Check for CHANGELOG file changes
+        run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin ${{ github.base_ref }} --depth=1
+          echo "$(git diff --name-only FETCH_HEAD)"
+          if [[ $(git diff --name-only FETCH_HEAD | grep --ignore-case CHANGELOG.md) ]]
+          then
+            echo "The CHANGELOG file was modified. Looks good!"
+          else
+            echo "The CHANGELOG file was not modified."
+            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
+            false
+          fi
+
+  lint-changelog:
+    runs-on: ubuntu-latest
+    needs: changelog-entry
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check if CHANGELOG is valid
+        uses: newrelic/release-toolkit/validate-markdown@v1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,39 +5,8 @@ name: changelog
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  changelog-entry:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.head_ref, 'renovate/')}}
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Debug Labels
-        run: |
-          echo "${{ toJson(github.event.pull_request.labels[*].name) }}"
-          echo "Should Run: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}"
-
-      - name: Check for CHANGELOG file changes
-        run: |
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          git fetch origin ${{ github.base_ref }} --depth=1
-          if [[ $(git diff --name-only FETCH_HEAD | grep --ignore-case CHANGELOG.md) ]]
-          then
-            echo "The CHANGELOG file was modified. Looks good!"
-          else
-            echo "The CHANGELOG file was not modified."
-            echo "Please add a CHANGELOG entry to the appropriate header under \"Unreleased\", or add the \"Skip Changelog\" label if not required."
-            false
-          fi
-
-  lint-changelog:
-    runs-on: ubuntu-latest
-    needs: changelog-entry
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Check if CHANGELOG is valid
-        uses: newrelic/release-toolkit/validate-markdown@v1
+  check-changelog:
+    uses: newrelic/k8s-metadata-injection/.github/workflows/changelog-reusable.yml@main


### PR DESCRIPTION
## Which problem is this PR solving?

Test using reusable workflow for changelog

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security fix
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## New Tests?

Please describe the new tests that were added (if applicable).

- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] e2e tests

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated