### PR TITLE
ci: Add Slack notifications to all workflows that do not involve pull requests

### DIFF
--- a/.github/workflows/release-chart-reusable.yml
+++ b/.github/workflows/release-chart-reusable.yml
@@ -5,6 +5,15 @@ on:
       gh_token:
         description: github token
         required: true
+      slack_channel:
+        description: slack channel for notifications
+        required: true
+      slack_token:
+        description: slack token for slack channel
+        required: true
+
+env:
+  ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
 
 jobs:
   #   Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
@@ -42,3 +51,15 @@ jobs:
         env:
           CR_SKIP_EXISTING: true
           CR_TOKEN: ${{ secrets.gh_token }}
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [validate-gh-pages-index, chart-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@b91c7e2ff3852411ad4fbdad441a8133221ac86e
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
+          slack-channel: ${{ secrets.slack_channel }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: <${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }}|'Release chart' failed>."

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -11,3 +11,5 @@ jobs:
     uses: newrelic/k8s-metadata-injection/.github/workflows/release-chart-reusable.yml@main
     secrets:
       gh_token: "${{ secrets.GITHUB_TOKEN }}"
+      slack_channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}

--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -241,4 +241,4 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
           slack-channel: ${{ secrets.slack_channel }}
-          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: <${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }}|release pipeline failed>."
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: <${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }}|'Pre-release and Release pipeline' failed>."

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -47,3 +47,15 @@ jobs:
         if: ${{ github.event.schedule }} # Upload sarif when running periodically
         with:
           sarif_file: 'trivy-results.sarif'
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [trivy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@b91c7e2ff3852411ad4fbdad441a8133221ac86e
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.K8S_AGENTS_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.K8S_AGENTS_SLACK_CHANNEL }}
+          slack-text: "❌ `k8s-metadata-injection`: <${{ github.server_url }}/k8s-metadata-injection/actions/runs/${{ github.run_id }}|'Security Scan' failed>."

--- a/.github/workflows/trigger-prerelease-reusable.yml
+++ b/.github/workflows/trigger-prerelease-reusable.yml
@@ -27,6 +27,9 @@ on:
         description: slack token for slack channel
         required: true
 
+env:
+  ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
+
 jobs:
   prerelease:
     uses: newrelic/coreint-automation/.github/workflows/trigger_prerelease.yaml@v1
@@ -38,3 +41,15 @@ jobs:
       bot_token: ${{ secrets.bot_token }}
       slack_channel:  ${{ secrets.slack_channel }}
       slack_token: ${{ secrets.slack_token }}
+
+  notify-failure:
+    if: ${{ always() && failure() }}
+    needs: [prerelease]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify failure via Slack
+        uses: archive/github-actions-slack@b91c7e2ff3852411ad4fbdad441a8133221ac86e
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.slack_token }}
+          slack-channel: ${{ secrets.slack_channel }}
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: <${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }}|'Trigger prerelease creation' failed>."


### PR DESCRIPTION
## Which problem is this PR solving?

Automate workflow notifications to Slack. That way we have only one source of truth to check for failing workflows.

For workflows that run for PRs, there is no need for automatic Slack notifications since merging will be blocked in the corresponding PR and author will be notified.

## Type of change

- [x] New feature / enhancement (non-breaking change which adds functionality)

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated