### PR TITLE
ci: Revert testing code in 'Security Scan' workflow

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,7 +1,6 @@
 name: Security Scan
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
@@ -48,8 +47,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
-        # if: ${{ github.event.schedule }} # Upload sarif when running periodically
-        if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }} # Upload sarif when running periodically
+        if: ${{ github.event.schedule }} # Upload sarif when running periodically
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
## Which problem is this PR solving?

Now that testing is done, revert testing changes.

## Type of change

- [x] New feature / enhancement (non-breaking change which adds functionality)

## Checklist:

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Tests have been added
- [ ] Documentation has been updated