### PR TITLE
ci: Make explicit that we are only using a single file

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -49,6 +49,12 @@ jobs:
         goos: [ linux ]
         goarch: [ amd64, arm64, arm ]
     steps:
+      - name: Build env args
+        run: |
+          echo "${{ github.event.release.tag_name }}" | grep -E '^[v]?[0-9.]*[0-9]$'
+          DOCKER_IMAGE_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_ENV
+          echo "DATE=`date`" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
@@ -62,6 +68,9 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          COMMIT: ${{ github.sha }}
+          DATE: ${{ env.DATE }}
+          TAG: ${{ env.DOCKER_IMAGE_TAG }}
         run: |
           make compile
       - name: Upload artifact for docker build step
@@ -80,6 +89,7 @@ jobs:
     env:
       DOCKER_IMAGE_NAME: ${{ inputs.docker_image_name }}
       DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/arm" # Must be consistent with the matrix from the job above
+      COMMIT: ${{ github.sha }}
     steps:
       - name: Generate docker image version from git tag
         id: set-new-version
@@ -87,6 +97,7 @@ jobs:
           echo "${{ github.event.release.tag_name }}" | grep -E '^[v]?[0-9.]*[0-9]$'
           DOCKER_IMAGE_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_ENV
+          echo "DATE=`date`" >> $GITHUB_ENV
           echo "new-version=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -126,6 +137,9 @@ jobs:
         run: |
           DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            --build-arg COMMIT=$COMMIT \
+            --build-arg DATE=$DATE \
+            --build-arg TAG=$DOCKER_IMAGE_TAG \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             .
       - name: Push release image
@@ -169,11 +183,14 @@ jobs:
         with:
           go-version: 1.19.11
 
-      - name: Checkout metadata injection repo
+      - name: Checkout version-update.go app
         uses: actions/checkout@v4
         with:
           repository: newrelic/k8s-metadata-injection
           ref: main
+          sparse-checkout: |
+            ./src/utils/version-update.go
+          sparse-checkout-cone-mode: false
 
       - name: Find next helm chart version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### enhancement
+- Make explicit that we are only using a single file by @juanjjaramillo in [#416](https://github.com/newrelic/k8s-metadata-injection/pull/416)
+
 ## v1.16.1 - 2023-09-26
 
 ### ⛓️ Dependencies


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
- It is confusing to download a specific repo in a reusable workflow. This PR makes it explicit that we are only interested in fetching a single file to allow us find the next version to use
- Pass through environment variables used to initialize first container log line

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  