### PR TITLE
fix: Add quotation to variables to handle spaces

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -137,9 +137,9 @@ jobs:
         run: |
           DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
-            --build-arg COMMIT=$COMMIT \
-            --build-arg DATE=$DATE \
-            --build-arg TAG=$DOCKER_IMAGE_TAG \
+            --build-arg "COMMIT=$COMMIT" \
+            --build-arg "DATE=$DATE" \
+            --build-arg "TAG=$DOCKER_IMAGE_TAG" \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             .
       - name: Push release image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.17.0 - 2023-09-28
 
+### bugfix
+- Add quotation to variables to handle spaces by @juanjjaramillo in [#417](https://github.com/newrelic/k8s-metadata-injection/pull/417)
+
 ### 🚀 Enhancements
 - Make explicit that we are only using a single file by @juanjjaramillo in [#416](https://github.com/newrelic/k8s-metadata-injection/pull/416)
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Flag `--build-arg` does not handle spaces, so quotations are needed to avoid error:
```
ERROR: "docker buildx build" requires exactly 1 argument.
```

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  