### PR TITLE
fix: Fix release workflow to include build-time metadata on release image

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -127,7 +127,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
-      - name: Build and push docker image
+      - name: Build and push docker prerelease image
         if: ${{ github.event.release.prerelease }}
         run: |
           DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}-pre
@@ -137,10 +137,13 @@ jobs:
             --build-arg "TAG=$DOCKER_IMAGE_TAG" \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             .
-      - name: Push release image
+      - name: Build and push docker release image
         if: ${{ ! github.event.release.prerelease }}
         run: |
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            --build-arg "COMMIT=$COMMIT" \
+            --build-arg "DATE=$DATE" \
+            --build-arg "TAG=$DOCKER_IMAGE_TAG" \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             -t $DOCKER_IMAGE_NAME:latest \
             .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### bugfix
+- Fix release workflow to include build-time metadata on release image by juanjjaramillo in [#425](https://github.com/newrelic/k8s-metadata-injection/pull/425)
+
 ## v1.18.0 - 2023-09-29
 
 ### 🚀 Enhancements


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
The release pipeline workflow is currently only including build-time metadata in the prerelease image. This PR adds the same metadata to the release image.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  