### PR TITLE
Unsafe webhooks

### DIFF
--- a/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/mutatingWebhookConfiguration.yaml
@@ -25,6 +25,7 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
 {{- if .Values.injectOnlyLabeledNamespaces }}
+    scope: Namespaced
   namespaceSelector:
     matchLabels:
       newrelic-metadata-injection: enabled


### PR DESCRIPTION
If a webhook is intercepting any resources in system-managed namespaces, or certain types of resources, they can be considered unsafe
Some information for GKE deployments https://cloud.google.com/kubernetes-engine/docs/how-to/optimize-webhooks?_ga=2.102213761.-1408611334.1679870533#unsafe-webhooks
So if injectOnlyLabeledNamespaces is true, the scope should be Namespaced not "*"