### PR TITLE
chore: Fix repo name in open-pr job in release-integration-reusable.yml

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Checkout input repo
         uses: actions/checkout@v4
         with:
-          repository: newrelic/${{ inputs.repo_name }}
+          repository: ${{ env.ORIGINAL_REPO_NAME }}
           ref: main
 
       - name: Find new appVersion


### PR DESCRIPTION
## Description
Replace checkout repo name with full repo name instead of using inputs.repo_name value. 

We use `inputs.repo_name` in the actions/upload-artifact@v3 step in `release-integration` reusable workflow which can be different than the repo name that is used by the actions/checkout@v4 when checking out the repo. 

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  