### PR TITLE
ci: Trivy scans should only run on the 'Security' workflow

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -125,14 +125,6 @@ jobs:
           docker buildx build --load --platform=linux/amd64 \
             -t $DOCKER_IMAGE_NAME:ci-scan \
             .
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.12.0
-        with:
-          image-ref: '${{ env.DOCKER_IMAGE_NAME }}:ci-scan'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'HIGH,CRITICAL'
       - name: Build and push docker prerelease image
         if: ${{ github.event.release.prerelease }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### bugfix
+- Trivy scans should only run on the 'Security' workflow by juanjjaramillo in [#436](https://github.com/newrelic/k8s-metadata-injection/pull/436)
+
 ## v1.18.3 - 2023-10-16
 
 ### 🐞 Bug fixes


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
We run Trivy scans on the security workflow, so it is counterproductive to block a release after a CVE is found

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  