### PR TITLE
feat: Upload sarif when running periodically or pushing to main

### DIFF
--- a/.github/workflows/security-reusable.yaml
+++ b/.github/workflows/security-reusable.yaml
@@ -46,7 +46,8 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
-        if: ${{ github.event.schedule }} # Upload sarif when running periodically
+        # Upload sarif when running periodically or pushing to main
+        if: ${{ github.event.schedule || (github.event_name == 'push' && github.ref_name == 'main') }}
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### enhancement
 - Remove 1.23 support by @svetlanabrennan in [#441](https://github.com/newrelic/k8s-metadata-injection/pull/441)
+- Upload sarif when running periodically or pushing to main in [#444](https://github.com/newrelic/k8s-metadata-injection/pull/444)
 
 ## v1.18.4 - 2023-10-23
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
Upload SARIF report from Trivy when running the 'Security' workflow in the `schedule` or `push` to `main` events. This will guarantee that once a vulnerability is fixed the Security tab on GitHub will be reflecting that.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  