### PR TITLE
feat: Improve Trivy scan by using Docker image

### DIFF
--- a/.github/workflows/security-reusable.yaml
+++ b/.github/workflows/security-reusable.yaml
@@ -31,14 +31,17 @@ jobs:
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'build'
           format: 'table'
-          exit-code: 1
+
+      - name: Build and load x64 image
+        run: |
+          docker buildx build --load --platform=linux/amd64 --tag trivy-scan:${{ github.sha }}
 
       - name: Run Trivy vulnerability scanner sarif output
         uses: aquasecurity/trivy-action@0.13.0
         # Upload sarif when running periodically or pushing to main
         if: ${{ github.event.schedule || (github.event_name == 'push' && github.ref_name == 'main') }}
         with:
-          scan-type: fs
+          image-ref: 'trivy-scan:${{ github.sha }}'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           skip-dirs: 'build'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### enhancement
 - Remove 1.23 support by @svetlanabrennan in [#441](https://github.com/newrelic/k8s-metadata-injection/pull/441)
 - Add k8s 1.28.0-rc.1 support by @svetlanabrennan in [#443](https://github.com/newrelic/k8s-metadata-injection/pull/443)
-- Upload sarif when running periodically or pushing to main in [#444](https://github.com/newrelic/k8s-metadata-injection/pull/444)
+- Upload sarif when running periodically or pushing to main by @juanjaramillo in [#444](https://github.com/newrelic/k8s-metadata-injection/pull/444)
+- Improve Trivy scan by using Docker image by @juanjjaramillo in [#446](https://github.com/newrelic/k8s-metadata-injection/pull/446)
 
 ## v1.18.4 - 2023-10-23
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change in your PR and what it's fixing.  -->
When Trivy runs on repo mode it does not check the base image in the `Dockerfile`. By using image mode, we get vulnerability reports for both the repo and any issues detected in the Docker image

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  