### PR TITLE
Provide input to the reusable release workflow to opt out of helm chart version updates

### DIFF
--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -11,6 +11,11 @@ on:
         description: The artifact path
         type: string
         required: false
+      disable_helm_chart_release:
+        description: Whether the release workflow should trigger a helm chart release or not
+        type: boolean
+        required: false
+        default: false
       docker_image_name:
         description: Docker image name
         type: string
@@ -150,7 +155,7 @@ jobs:
     needs: [ docker-integration ]
     runs-on: ubuntu-latest
     # run only for releases (not prereleases)
-    if: ${{ ! github.event.release.prerelease }}
+    if: ${{ ! github.event.release.prerelease && inputs.disable_helm_chart_release }}
     steps:
       - name: Checkout original repo
         uses: actions/checkout@v4

--- a/.github/workflows/release-integration-reusable.yml
+++ b/.github/workflows/release-integration-reusable.yml
@@ -11,11 +11,11 @@ on:
         description: The artifact path
         type: string
         required: false
-      disable_helm_chart_release:
+      enable_helm_chart_release:
         description: Whether the release workflow should trigger a helm chart release or not
         type: boolean
         required: false
-        default: false
+        default: true
       docker_image_name:
         description: Docker image name
         type: string
@@ -155,7 +155,7 @@ jobs:
     needs: [ docker-integration ]
     runs-on: ubuntu-latest
     # run only for releases (not prereleases)
-    if: ${{ ! github.event.release.prerelease && inputs.disable_helm_chart_release }}
+    if: ${{ ! github.event.release.prerelease && inputs.enable_helm_chart_release }}
     steps:
       - name: Checkout original repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

This PR updates the reusable release workflow to be compatible for the [newrelic/newrelic-pixie-integration](https://github.com/newrelic/newrelic-pixie-integration) repo. The helm chart for that repository lives in the newrelic/helm-charts repo and so it prevents the reusable workflow from appearing successful despite the release images being pushed prior to failure.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests) -- _I didn't feel this should be added to the changelog, but let me know if you'd prefer it to be added_
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [x] E2E tests -- Verified the toggle correctly disables the helm chart release in https://github.com/newrelic/newrelic-pixie-integration/pull/144
  