### PR TITLE
chore: add container security context to admission webhook jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### enhancements
+- Pass container security context into admission webhooks @kondracek-nr [#619](https://github.com/newrelic/k8s-metadata-injection/pull/619)
+
 ## v1.33.1 - 2025-05-05
 
 ### ⛓️ Dependencies

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-createSecret.yaml
@@ -30,6 +30,10 @@ spec:
         - name: create
           image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.jobImage "context" .) }}
           imagePullPolicy: {{ .Values.jobImage.pullPolicy }}
+          {{- with include "newrelic.common.securityContext.container" . }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           args:
             - create
             - --host={{ include "newrelic.common.naming.fullname" . }},{{ include "newrelic.common.naming.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
+++ b/charts/nri-metadata-injection/templates/admission-webhooks/job-patch/job-patchWebhook.yaml
@@ -30,6 +30,10 @@ spec:
         - name: patch
           image: {{ include "newrelic.common.images.image" ( dict "defaultRegistry" "registry.k8s.io" "imageRoot" .Values.jobImage "context" .) }}
           imagePullPolicy: {{ .Values.jobImage.pullPolicy }}
+          {{- with include "newrelic.common.securityContext.container" . }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           args:
             - patch
             - --webhook-name={{ include "newrelic.common.naming.fullname" . }}


### PR DESCRIPTION
## Description
A customer recently reported that `allowPrivilegeEscalation=false` wasn't working on the admission webhooks in k8s-metadata-injection. This change allows `containerSecurityContext` to be passed into the admission webhook job templates as it is in the deployment.

Logs look normal & metadata is added to new pods as expected
```
kn logs newrelic-bundle-nri-metadata-injection-admission-create-mpm6b
W0515 19:12:01.304876       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"err":"secrets \"newrelic-bundle-nri-metadata-injection-admission\" not found","level":"info","msg":"no secret found","source":"k8s/k8s.go:229","time":"2025-05-15T19:12:01Z"}
{"level":"info","msg":"creating new secret","source":"cmd/create.go:28","time":"2025-05-15T19:12:01Z"}

kn logs newrelic-bundle-nri-metadata-injection-admission-patch-z9jh6
W0515 19:12:05.749301       1 client_config.go:618] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"level":"info","msg":"patching webhook configurations 'newrelic-bundle-nri-metadata-injection' mutating=true, validating=false, failurePolicy=","source":"k8s/k8s.go:118","time":"2025-05-15T19:12:05Z"}
{"level":"info","msg":"Patched hook(s)","source":"k8s/k8s.go:138","time":"2025-05-15T19:12:05Z"}
```

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
  